### PR TITLE
Fix Author Roles extension when using unique admin URLs

### DIFF
--- a/content/content.index.php
+++ b/content/content.index.php
@@ -10,7 +10,7 @@
 		 * Constructor
 		 */
 		function __construct(){
-			$this->_uri = URL . '/symphony/extension/author_roles/';
+			$this->_uri = SYMPHONY_URL . '/extension/author_roles/';
 			$this->_driver = Symphony::ExtensionManager()->create('author_roles');
 			parent::__construct();
 		}

--- a/content/content.roles.php
+++ b/content/content.roles.php
@@ -13,7 +13,7 @@
 		
 		function __construct(){
 			parent::__construct();
-			$this->_uri = URL . '/symphony/extension/author_roles/';
+			$this->_uri = SYMPHONY_URL . '/extension/author_roles/';
 			$this->_driver = Symphony::ExtensionManager()->create('author_roles');
 		}
 		


### PR DESCRIPTION
Fix Author Roles extension so it works when the symphony admin URL is not /symphony/ .